### PR TITLE
add network diagram

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -15,6 +15,7 @@
     "nwaku",
     "deanonymization",
     "ECIES",
+    "enrtree",
     "Discv5",
     "Gossipsub",
     "LIGHTPUSH",

--- a/static/discv5.md
+++ b/static/discv5.md
@@ -1,0 +1,29 @@
+
+```mermaid
+sequenceDiagram
+    Alice->>DNS Server: (1) Execute DNS Discovery
+    DNS Server-->>Alice: (2) Bob's connection details (UDP + TCP)
+    activate Alice
+    Alice->>Bob: (3) Execute Discv5 over UDP
+    Bob-->>Alice: (4) ENRs (UDP + TCP): Carol, David, Erin
+    Alice->>Alice: (5) Decode ENRs
+    Alice->>Carol: (6) Execute Discv5 over UDP
+    Carol-->>Alice: (7) ENRs (UDP + TCP): Frank, Gwen, Harry
+    Alice->>Alice: (8) Decode ENRs
+    deactivate Alice
+    Alice->>Alice: (9) Select peers to dial
+    Alice->>David: (10) Libp2p dial (TCP)
+    Alice->>Frank: (10) Libp2p dial (TCP)
+    Alice->>Gwen: (10) Libp2p dial (TCP)
+```
+
+1. DNS Discovery protocol is executed.
+2. Alice's retrieves Bob's ENR (Ethereum Node Record) from DNS Server.
+3. Alice executes Discv5 protocol with Bob using UDP connection details from ENR.
+4. Bob returns Carol's, David's and Erin's ENRs to Alice.
+5. Alice Decodes ENRs and extracts Carol's, David's and Erin's TCP and UDP connections details.
+6. Alice executes Discv5 protocol with Carol using UDP connection details from ENR.
+7. Carol returns Frank's, Gwen's and Harry's ENRs to Alice.
+8. Alice Decodes ENRs and extracts Frank's, Gwen's and Harry's TCP and UDP connections details.
+9. Alice selects to dial David, Frank and Gwen.
+10. Alice dials David, Frank and Gwen over libp2p using TCP connections details from ENRs.

--- a/static/dns_discovery.md
+++ b/static/dns_discovery.md
@@ -1,0 +1,20 @@
+
+
+```mermaid
+sequenceDiagram
+    Waku Node->>DNS Server: (1) Lookup TXT example.com
+    DNS Server-->>Waku Node: (2) enrtree-root:v1 e=U3...3Y ...
+    Waku Node->>DNS Server: (3) Lookup TXT U3...3Y.example.com
+    DNS Server-->>Waku Node: (4) enrtree-branch:DU...VQ,J3..HU,IC...WE
+    Waku Node->> DNS Server: (5) Lookup TXT DU...VQ.example.com
+    DNS Server-->>Waku Node: (6) enr:-M-4QLdAB-Kyz...Wt1Mg8
+    Waku Node ->> Waku Node: (7) Decode ENR: Peer's connection details
+```
+
+1. DNS lookup query to retrieve TXT data stored on `example.com` domain.
+2. `entree-root` is returned, value of `e` is the `enr-root`, root hash of the node subtree.
+3. DNS lookup query to retrieve TXT data stored on `<enr-root>.example.com` domain.
+4. `entree-branch` is returned, this tree contains hashes of node subtrees.
+5. DNS lookup query to retrieve TXT data stored on, `DU...VQ.example.com` domain,  the first leaf of `entree-branch`.
+6. `enr` record is returned.
+7. Returned value is decoded, peer connection details such as ip address and port are learned.

--- a/static/peer_exchange.md
+++ b/static/peer_exchange.md
@@ -1,0 +1,22 @@
+
+```mermaid
+sequenceDiagram
+    Alice->>DNS Server: (1) Execute DNS Discovery
+    DNS Server-->>Alice: (2) Bob's multiaddr (websocket)
+    Alice-->>Bob: (3) Dial
+    Alice->>Bob: (4) Peer Exchange Query
+    Bob-->>Alice: (5) Carol's ENR, David's ENR
+    Alice->>Alice: (6) Decode ENRs
+    Alice->>Carol: (7) Dial
+    Alice->>David: (7) Dial
+    Alice-->>Bob: (8) Disconnect
+```
+
+1. DNS Discovery protocol is executed.
+2. Alice's retrieves Bob's websocket multiaddr from DNS Server.
+3. Alice dials Bob using libp2p protocols.
+4. Alice executes a Peer Exchange Query to Bob.
+5. Bob returns Carol's and David's ENR to Alice.
+6. Alice Decodes ENRs and extracts Carol's and David's websocket multiaddrs.
+7. Alice dials Carol and David.
+8. Alice can now drop the connection with Bob (bootstrap node), Alice has 2 connections to the Waku Network.


### PR DESCRIPTION
Ref  #7 tackling:

> (1) Message flow architecture diagram:
	- Shows Waku Relay and pubsub topic message routing
	- Shows Filter/Light Push/Store usage with content topic usage/filtering.
	- could include information about transports used (tcp, websocket) if does not make it too busy
	- Include adaptive node information: cloud vs laptop (native) vs mobile vs browser
>  (2) architecture diagram of Discovery: DNS Discovery + Discv5 + peer exchange + peer persistence

Review tip: click "view file" to have GitHub render the mermaid code.